### PR TITLE
Added support to handle form data definition in step

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -166,7 +166,7 @@ class WebApiContext implements ApiClientAwareContext
         foreach ($fields as $key => $value) {
             if(is_array($value)) {
                 foreach ($value as $formKey => $formValue) {
-                    $requestFields[] = sprintf('%s[%s]=%s', urlencode($key), urlencode($formKey), urlencode($formValue));
+                    $requestFields[] = sprintf('%s%s=%s', urlencode($key), urlencode('[' . $formKey . ']'), urlencode($formValue));
                 }
             } else {
                 $requestFields[] = sprintf('%s=%s', urlencode($key), urlencode($value));

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -164,7 +164,13 @@ class WebApiContext implements ApiClientAwareContext
         parse_str(implode('&', explode("\n", $body)), $fields);
 
         foreach ($fields as $key => $value) {
-            $requestFields[] = sprintf('%s=%s', urlencode($key), urlencode($value));
+            if(is_array($value)) {
+                foreach ($value as $formKey => $formValue) {
+                    $requestFields[] = sprintf('%s[%s]=%s', urlencode($key), urlencode($formKey), urlencode($formValue));
+                }
+            } else {
+                $requestFields[] = sprintf('%s=%s', urlencode($key), urlencode($value));
+            }
         }
 
         $requestBody = implode('&', $requestFields);


### PR DESCRIPTION
This change allows you to define post data in the format Element[key]=Value in an scenario. Since the current implementation does not support this functionality.

Given I send a POST request to "URL" with form data:
"""
RatingForm[title]=Title
RatingForm[comment]=Comment
RatingForm[name]=Customer
"""