### PR TITLE
Branch alias should be 1.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Because if I try to require `~1.0`, composer will try to fetch `1.0.x-dev`.

`1.x` will be more generic and painless to maintain.

If you don't want that, at least, please update it to `1.2.x-dev`.