### PR TITLE
WebApiContext::getResponse() returns \Psr\Http\Message\ResponseInterface

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -298,7 +298,7 @@ class WebApiContext implements ApiClientAwareContext
     }
 
     /**
-     * @return \GuzzleHttp\Message\ResponseInterface
+     * @return ResponseInterface
      */
     public function getResponse()
     {


### PR DESCRIPTION
\Behat\WebApiExtension\Context\WebApiContext::getResponse() returns \Psr\Http\Message\ResponseInterface, not \GuzzleHttp\Message\ResponseInterface.