### PR TITLE
feat: upgrade guzzlehttp to 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
+  - 7.2.5
   - hhvm
 
 before_install:
@@ -26,5 +24,4 @@ after_failure:
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.2.5
+  - 7.2
   - hhvm
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
-        "guzzlehttp/guzzle": "~6",
+        "guzzlehttp/guzzle": "~7",
         "phpunit/phpunit": ">=6.0"
     },
     "require-dev": {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -119,7 +119,7 @@ class FeatureContext implements SnippetAcceptingContext
      */
     public function theOutputShouldContain(PyStringNode $text)
     {
-        PHPUnit_Framework_Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
+        \PHPUnit\Framework\Assert::assertContains($this->getExpectedOutput($text), $this->getOutput());
     }
 
     private function getExpectedOutput(PyStringNode $expectedText)
@@ -162,13 +162,13 @@ class FeatureContext implements SnippetAcceptingContext
                 echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            PHPUnit_Framework_Assert::assertNotEquals(0, $this->getExitCode());
+            \PHPUnit\Framework\Assert::assertNotEquals(0, $this->getExitCode());
         } else {
             if (0 !== $this->getExitCode()) {
                 echo 'Actual output:' . PHP_EOL . PHP_EOL . $this->getOutput();
             }
 
-            PHPUnit_Framework_Assert::assertEquals(0, $this->getExitCode());
+            \PHPUnit\Framework\Assert::assertEquals(0, $this->getExitCode());
         }
     }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -44,7 +44,7 @@ class FeatureContext implements SnippetAcceptingContext
     public function prepareScenario()
     {
         $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat-web-api' . DIRECTORY_SEPARATOR .
-            md5(microtime() * rand(0, 10000));
+            md5(microtime() . rand(0, 10000));
 
         mkdir($dir . '/features/bootstrap', 0777, true);
 

--- a/features/context.feature
+++ b/features/context.feature
@@ -24,7 +24,7 @@ Feature: client aware context
            * @Then /^the client should be set$/
            */
           public function theClientShouldBeSet() {
-              PHPUnit_Framework_Assert::assertInstanceOf('GuzzleHttp\Client', $this->client);
+              \PHPUnit\Framework\Assert::assertInstanceOf('GuzzleHttp\Client', $this->client);
           }
       }
       """

--- a/features/testapp.feature
+++ b/features/testapp.feature
@@ -218,8 +218,9 @@ Feature: Test app verification
 
       --- Failed steps:
 
-          And the response should contain json: # features/send_values.feature:11
-            Failed asserting that '123' matches PCRE pattern "/[a-z]+/".
+    001 Scenario:                               # features/send_values.feature:6
+            And the response should contain json: # features/send_values.feature:11
+              Failed asserting that '123' matches PCRE pattern "/[a-z]+/".
 
       1 scenario (1 failed)
       3 steps (2 passed, 1 failed)


### PR DESCRIPTION
Upgrade guzzlehttp to version 7. This will allow to install `sentry/sentry-symfony 4` for the client applications

Breaking changes

* Drop support for php < 7.2