### PR TITLE
fix: avoid duplicate headers

### DIFF
--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -366,6 +366,9 @@ class WebApiContext implements ApiClientAwareContext
     protected function addHeader($name, $value)
     {
         if (isset($this->headers[$name])) {
+            if ($this->headers[$name] === $value) {
+                return;
+            }
             if (!is_array($this->headers[$name])) {
                 $this->headers[$name] = array($this->headers[$name]);
             }


### PR DESCRIPTION
The behavior I found in php `8.1.18` alpine images.
I have a scenario to Given to add header Content-Type application/json, also I have `And` to another request with change the `Content-Type` application/json, the same value.

This turns the `Content-Type: application/json, application/json`, this behavior is a wrong content-type, and that framework cannot identify a valid application/json.