### PR TITLE
fix: consider null values on json asserts

### DIFF
--- a/features/testapp.feature
+++ b/features/testapp.feature
@@ -292,3 +292,37 @@ Feature: Test app verification
 
       1 scenario (1 passed)
       """
+
+  Scenario: Responses with null expected values should work
+    Given a file named "features/null_handling.feature" with:
+      """
+      Feature: Exercise WebApiContext data receiving
+        In order to validate the send response step
+        As a context developer
+        I need to be able to send a request with null values and expect them in a scenario
+
+        Scenario:
+          Given I set header "content-type" with value "application/json"
+          When I send a POST request to "echo" with body:
+          '''
+          {
+          "name" : "name",
+          "pass": null
+          }
+          '''
+          Then the response should contain "POST"
+          And the response should contain json:
+          '''
+          {
+          "name" : "name",
+          "pass": null
+          }
+          '''
+      """
+    When I run "behat features/null_handling.feature"
+    Then it should pass with:
+      """
+      ..
+
+      1 scenario (1 passed)
+      """

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -268,6 +268,12 @@ class WebApiContext implements ApiClientAwareContext
             return;
         }
 
+        if (is_null($expected)) {
+            Assertions::assertEquals($expected, $actual, 'JSON equality');
+
+            return;
+        }
+
         if (preg_match('/^\%.+\%$/', $expected, $result)) {
             $pattern = sprintf('/%s/', trim($result[0], '%'));
             Assertions::assertMatchesRegularExpression($pattern, $actual);

--- a/src/Context/WebApiContext.php
+++ b/src/Context/WebApiContext.php
@@ -268,13 +268,7 @@ class WebApiContext implements ApiClientAwareContext
             return;
         }
 
-        if (is_null($expected)) {
-            Assertions::assertEquals($expected, $actual, 'JSON equality');
-
-            return;
-        }
-
-        if (preg_match('/^\%.+\%$/', $expected, $result)) {
+        if (preg_match('/^\%.+\%$/', $expected ?? '', $result)) {
             $pattern = sprintf('/%s/', trim($result[0], '%'));
             Assertions::assertMatchesRegularExpression($pattern, $actual);
 


### PR DESCRIPTION
# Goal

Add support for `Null` values on `ResponseShouldContainJson` with PHP >= 8.1

# Fixed error:
Avoid throw error when I have a scenario to Given to validate a response json with `null` values.

```
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in vendor/linio/behat-web-api-extension/src/Context/WebApiContext.php line 271
``` 